### PR TITLE
Fix SSL mode parameter

### DIFF
--- a/db_gen.go
+++ b/db_gen.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-//BuildConnString builds the connection string from file
+// BuildConnString builds the connection string from file
 func BuildConnString(dbUser string, password string, dbName string, server string, useSSL bool) string {
 
 	var buffer bytes.Buffer
@@ -27,13 +27,14 @@ func BuildConnString(dbUser string, password string, dbName string, server strin
 	if !useSSL {
 		buffer.WriteString("disable")
 	} else {
-		buffer.WriteString("enable")
+		// lib/pq expects "require" to enable SSL
+		buffer.WriteString("require")
 	}
 
 	return buffer.String()
 }
 
-//CreateOrAlterTables creates and alters tables based on the struct definition file
+// CreateOrAlterTables creates and alters tables based on the struct definition file
 func CreateOrAlterTables(structObj *structToCreate, db *sql.DB, group string) {
 	var tablePathName string = fmt.Sprintf("%s.%s.%s", AddQuotesIfAnyUpperCase(structObj.database), AddQuotesIfAnyUpperCase(structObj.schema), structObj.tableName)
 	var oldTableName string


### PR DESCRIPTION
## Summary
- use valid `sslmode=require` in the Postgres connection string builder

## Testing
- `GO111MODULE=off go build ./...` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_68421fd5d000832eaa32c972e6931ef6