### PR TITLE
Add robust string tests and update license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Daniel Isted
+Copyright (c) 2014-2025 Daniel Isted
 
 The MIT License (MIT)
 

--- a/string_fns_test.go
+++ b/string_fns_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func TestConvertToUnderscore(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"camel", "CamelCaseID", "camel_case_id", false},
+		{"simple", "Simple", "simple", false},
+		{"acronym", "HTTPServer", "http_server", false},
+		{"invalid start", "1abc", "", true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ConvertToUnderscore(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for input %q", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ConvertToUnderscore(%q) returned error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("ConvertToUnderscore(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTrimInnerSpacesToOne(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"leading and trailing", "  Hello   world  ", "Hello world"},
+		{"tabs and spaces", "a\t\tb   c", "a b c"},
+		{"only spaces", "   ", ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TrimInnerSpacesToOne(tc.in); got != tc.want {
+				t.Errorf("TrimInnerSpacesToOne(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- expand string utility tests with subtests and error case
- update MIT license year range and ensure trailing newline

## Testing
- `go test ./...` *(fails: directory prefix does not contain main module)*
- `GO111MODULE=off go test ./...` *(fails: cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_684223838f68832e9c17c5acd1dc9732