### PR TITLE
Fix ConvertToUnderscore

### DIFF
--- a/string_fns.go
+++ b/string_fns.go
@@ -8,32 +8,38 @@ import (
 )
 
 func ConvertToUnderscore(camel string) (string, error) {
-	var prevRune rune
-	var underscore []rune
-	for index, runeChar := range camel {
-		if index == 0 {
-			if !unicode.IsLetter(runeChar) {
-				return "", fmt.Errorf("Table and column names can't start with a character other than a letter.")
-			}
-			underscore = append(underscore, unicode.ToLower(runeChar))
-			prevRune = runeChar
-		} else {
-			if runeChar == '_' || unicode.IsLetter(runeChar) || unicode.IsDigit(runeChar) {
-				//Look for Upper case letters, append _ and make character lower case
-				if unicode.IsUpper(runeChar) {
-					if !unicode.IsUpper(prevRune) {
-						underscore = append(underscore, '_')
-					}
-					underscore = append(underscore, unicode.ToLower(runeChar))
-				} else {
-					underscore = append(underscore, runeChar)
-				}
-			} else {
-				return "", fmt.Errorf("Table and column names can't contain non-alphanumeric characters.")
-			}
-		}
-		prevRune = runeChar
+	if camel == "" {
+		return "", nil
 	}
+
+	runes := []rune(camel)
+	if !unicode.IsLetter(runes[0]) {
+		return "", fmt.Errorf("Table and column names can't start with a character other than a letter.")
+	}
+
+	var underscore []rune
+	underscore = append(underscore, unicode.ToLower(runes[0]))
+
+	for i := 1; i < len(runes); i++ {
+		r := runes[i]
+
+		if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+			return "", fmt.Errorf("Table and column names can't contain non-alphanumeric characters.")
+		}
+
+		prev := runes[i-1]
+
+		if unicode.IsUpper(r) {
+			nextIsLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if prev != '_' && (unicode.IsLower(prev) || (unicode.IsUpper(prev) && nextIsLower)) {
+				underscore = append(underscore, '_')
+			}
+			underscore = append(underscore, unicode.ToLower(r))
+		} else {
+			underscore = append(underscore, r)
+		}
+	}
+
 	return string(underscore), nil
 }
 

--- a/string_fns_test.go
+++ b/string_fns_test.go
@@ -10,6 +10,7 @@ func TestConvertToUnderscore(t *testing.T) {
 		{"CamelCaseID", "camel_case_id"},
 		{"Simple", "simple"},
 		{"HTTPServer", "http_server"},
+		{"Camel_Case", "camel_case"},
 	}
 	for _, tt := range tests {
 		got, err := ConvertToUnderscore(tt.in)


### PR DESCRIPTION
## Summary
- fix ConvertToUnderscore to correctly handle mixed acronyms and underscores
- add regression test for ConvertToUnderscore

## Testing
- `go test string_fns.go string_fns_test.go`
- `GO111MODULE=off go test ./...` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_68437d1a7100832e8f3b6f10f60aa834