### PR TITLE
Fix example struct tags

### DIFF
--- a/examples/DefinitionFiles/crudGen.txt
+++ b/examples/DefinitionFiles/crudGen.txt
@@ -15,9 +15,9 @@ StreetCRUD
 [prepared] true
 type User struct {
 	LoginID  int    `json:"loginid"` [primary]
-	Name     string `json:"name, omitempty"` [index]   [patch][size:255]
-	Email    string `json:"email”`[index] [nulls]
+	Name     string `json:"name,omitempty"` [index]   [patch][size:255]
+	Email    string `json:"email"`[index] [nulls]
 	Password string `json:"password" out:"false"`
-	DeletedUser bool `json:”deleted”` [nulls][deleted]
-	DelOn	   time.Time   `json:”deletedon”`[deletedOn]  [nulls]
+	DeletedUser bool `json:"deleted"` [nulls][deleted]
+	DelOn      time.Time   `json:"deletedon"`[deletedOn]  [nulls]
 }

--- a/examples/DefinitionFiles/crudGenAlt.txt
+++ b/examples/DefinitionFiles/crudGenAlt.txt
@@ -20,7 +20,7 @@ email [to] Email
 [prepared] false
 type UserA struct {
 	LogID int `json:"loginid"`	 	[primary]
-	UserName string `json:”userName”` [index][patch][size:255]
-	Phone string `json:”phone”` [nulls]
-	Email string `json:”email”` [nulls]
+	UserName string `json:"userName"` [index][patch][size:255]
+	Phone string `json:"phone"` [nulls]
+	Email string `json:"email"` [nulls]
 }

--- a/examples/UsesGeneratedCode/main.go
+++ b/examples/UsesGeneratedCode/main.go
@@ -102,7 +102,7 @@ func main() {
 	user3.Delete()
 	fmt.Printf("%s (LoginID: %d) was permanently deleted.\n", user3.Name, user3.LoginID)
 
-	//Patch Email
+        //Patch Name
 	fmt.Printf("%s's name has been changed to ", user4.Name)
 	user4.PatchName("Shallan")
 	fmt.Printf("%s.\n", user4.Name)

--- a/examples/UsesGeneratedCode/models/user.go
+++ b/examples/UsesGeneratedCode/models/user.go
@@ -18,12 +18,12 @@ const (
 )
 
 type User struct {
-	LoginID     int              `json:"loginid"`
-	Name        string           `json:"name, omitempty"`
-	Email       nulls.String `json:"email”`
-	Password    string           `json:"password" out:"false"`
-	DeletedUser bool             `json:”deleted”`
-	DelOn       nulls.Time   `json:”deletedon”`
+        LoginID     int          `json:"loginid"`
+        Name        string       `json:"name,omitempty"`
+        Email       nulls.String `json:"email"`
+        Password    string       `json:"password" out:"false"`
+        DeletedUser bool         `json:"deleted"`
+        DelOn       nulls.Time   `json:"deletedon"`
 }
 
 //Initialize and fill a User object from the DB


### PR DESCRIPTION
## Summary
- clean up invalid quotes in example `user.go` model
- fix comment in example main
- normalize struct tags in example CRUD definition files

## Testing
- `go test -vet=off ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68460420cb84832e99b8bd4131e589f6